### PR TITLE
Add .include keyword

### DIFF
--- a/src/generators/c_generator.cpp
+++ b/src/generators/c_generator.cpp
@@ -133,7 +133,7 @@ str C_Generator::transform(Language other, const str &string) {
         case ASSEMBLY:
             return "asm(\"" + string + "\");\n";
         default:
-            print_error("at line " + current_line + ": incompatible language used");
+            print_error(global.filename + " at line " + current_line + ": incompatible language used");
             exit(1);
     }
 }
@@ -172,11 +172,11 @@ str C_Generator::name() {
 
 str C_Generator::generate_for_start(const str &v, int f, int t) {
     if(t < f) {
-        print_error("at line " + current_line + ": [for] <to> (" + std::to_string(t) + ") cannot be less than <from> (" + std::to_string(f) + ")");
+        print_error(global.filename + " at line " + current_line + ": [for] <to> (" + std::to_string(t) + ") cannot be less than <from> (" + std::to_string(f) + ")");
         exit(1);
     }
     if(t == f) {
-        print_warning("at line " + current_line + ": dead code");
+        print_warning(global.filename + " at line " + current_line + ": dead code");
     }
     str s = indent() + "for(int " + v + " = " + std::to_string(f) + "; " + v + " < " + std::to_string(t) + "; " + v +
             "++) {\n";
@@ -191,10 +191,10 @@ str C_Generator::generate_for_end() {
 
 str C_Generator::generate_while_start(const str &condition) {
     if(condition == "true") {
-        print_warning("at line " + current_line + ": infinite loop");
+        print_warning(global.filename + " at line " + current_line + ": infinite loop");
     }
     if(condition == "false") {
-        print_warning("at line " + current_line + ": dead code");
+        print_warning(global.filename + " at line " + current_line + ": dead code");
     }
     str s = indent() + "while(" + condition + ") {\n";
     _indent++;
@@ -214,10 +214,10 @@ str C_Generator::generate_postwhile_start() {
 
 str C_Generator::generate_postwhile_end(const str &condition) {
     if(condition == "true") {
-        print_warning("at line " + current_line + ": infinite loop");
+        print_warning(global.filename + " at line " + current_line + ": infinite loop");
     }
     if(condition == "false") {
-        print_warning("at line " + current_line + ": single run postwhile (consider removing postwhile loop here)");
+        print_warning(global.filename + " at line " + current_line + ": single run postwhile (consider removing postwhile loop here)");
     }
     _indent--;
     return indent() + "} while(" + condition + ");\n";

--- a/src/generators/cpp_generator.cpp
+++ b/src/generators/cpp_generator.cpp
@@ -86,14 +86,14 @@ str CPP_Generator::generate_class_visibility(const str &vis) {
     if(vis == "public" || vis == "private" || vis == "protected")
         return indent() + vis + ":\n";
     else {
-        print_error("at line " + current_line + ": invalid visibility `" + vis + "`");
+        print_error(global.filename + " at line " + current_line + ": invalid visibility `" + vis + "`");
         exit(1);
     }
 }
 
 str CPP_Generator::generate_class_start(const str &name, str *bases, long count) {
     if(class_info._class) {
-        print_error("at line " + current_line + ": cannot nest classes");
+        print_error(global.filename + " at line " + current_line + ": cannot nest classes");
         exit(1);
     }
     str out = "\n" + indent() + "class " + name;
@@ -114,11 +114,11 @@ str CPP_Generator::generate_class_start(const str &name, str *bases, long count)
 
 str CPP_Generator::generate_class_end() {
     if(!class_info._class) {
-        print_error("at line " + current_line + ": attempted to use `end class` when no class is being defined");
+        print_error(global.filename + " at line " + current_line + ": attempted to use `end class` when no class is being defined");
         exit(1);
     }
     if(class_info._unimpl) {
-        print_warning("at line " + current_line + ": used `end class` on an interface (ok for C++)");
+        print_warning(global.filename + " at line " + current_line + ": used `end class` on an interface (ok for C++)");
     }
     class_info._class = false;
     _indent--;
@@ -135,11 +135,11 @@ str CPP_Generator::generate_interface_start(const str &name) {
 
 str CPP_Generator::generate_interface_end() {
     if(!class_info._class) {
-        print_error("at line " + current_line + ": attempted to use `end interface` when no interface is being defined");
+        print_error(global.filename + " at line " + current_line + ": attempted to use `end interface` when no interface is being defined");
         exit(1);
     }
     if(!class_info._unimpl) {
-        print_warning("at line " + current_line + ": used `end interface` on an class (ok for C++)");
+        print_warning(global.filename + " at line " + current_line + ": used `end interface` on an class (ok for C++)");
     }
     class_info._class = false;
     class_info._unimpl = false;
@@ -179,7 +179,7 @@ str CPP_Generator::transform(Language other, const str &string) {
         case ASSEMBLY:
             return "asm(\"" + string + "\");\n";
         default:
-            print_error("at line " + current_line + ": incompatible language used");
+            print_error(global.filename + " at line " + current_line + ": incompatible language used");
             exit(1);
     }
 }
@@ -224,11 +224,11 @@ str CPP_Generator::generate_include(str file, bool library) {
 
 str CPP_Generator::generate_for_start(const str &v, int f, int t) {
     if(t < f) {
-        print_error("at line " + current_line + ": [for] <to> (" + std::to_string(t) + ") cannot be less than <from> (" + std::to_string(f) + ")");
+        print_error(global.filename + " at line " + current_line + ": [for] <to> (" + std::to_string(t) + ") cannot be less than <from> (" + std::to_string(f) + ")");
         exit(1);
     }
     if(t == f) {
-        print_warning("at line " + current_line + ": dead code");
+        print_warning(global.filename + " at line " + current_line + ": dead code");
     }
     str s = indent() + "for(int " + v + " = " + std::to_string(f) + "; " + v + " < " + std::to_string(t) + "; " + v +
             "++) {\n";
@@ -243,10 +243,10 @@ str CPP_Generator::generate_for_end() {
 
 str CPP_Generator::generate_while_start(const str &condition) {
     if(condition == "true") {
-        print_warning("at line " + current_line + ": infinite loop");
+        print_warning(global.filename + " at line " + current_line + ": infinite loop");
     }
     if(condition == "false") {
-        print_warning("at line " + current_line + ": dead code");
+        print_warning(global.filename + " at line " + current_line + ": dead code");
     }
     str s = indent() + "while(" + condition + ") {\n";
     _indent++;
@@ -266,10 +266,10 @@ str CPP_Generator::generate_postwhile_start() {
 
 str CPP_Generator::generate_postwhile_end(const str &condition) {
     if(condition == "true") {
-        print_warning("at line " + current_line + ": infinite loop");
+        print_warning(global.filename + " at line " + current_line + ": infinite loop");
     }
     if(condition == "false") {
-        print_warning("at line " + current_line + ": single run postwhile (consider removing postwhile loop here)");
+        print_warning(global.filename + " at line " + current_line + ": single run postwhile (consider removing postwhile loop here)");
     }
     _indent--;
     return indent() + "} while(" + condition + ");\n";

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -81,6 +81,7 @@ int main(int argc, char **argv) {
     global.output
             ->flush();
     global.line = 0;
+    global.filename = parse.nonOption(0);
 
     comments = !options[NO_COMMENT];
 

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -1,7 +1,7 @@
 #include "simon.h"
 #include <iostream>
 #include <generator.h>
-#include <cstring>
+#include <fstream>
 
 bool comment_mode;
 void parse_line(str str);
@@ -297,6 +297,12 @@ void parse_line(str s) {
                 modDef[j] = '$';
         }
         *global.output << "#ifdef " << modDef << std::endl;
+    } else if (name == ".include") {
+        auto input = std::ifstream(args.front());
+        auto linenum = global.line;
+        global.line = 0;
+        while (!!input) ::parse(&input);
+        global.line = linenum;
     } else {
         str argsv[args.size()];
         int j = 0;

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -59,7 +59,7 @@ extern bool comments;
 
 void parse_line(str s) {
 #if TESTING == true
-    print_info(current_line + " : " + s);
+    print_info(current_line + " " + global.filename + " : " + s);
 #endif
     auto generator = for_language(global.language);
     if (s == "/language: cpp/") {
@@ -300,9 +300,12 @@ void parse_line(str s) {
     } else if (name == ".include") {
         auto input = std::ifstream(args.front());
         auto linenum = global.line;
+        auto filename = global.filename;
         global.line = 0;
+        global.filename = args.front();
         while (!!input) ::parse(&input);
         global.line = linenum;
+        global.filename = filename;
     } else {
         str argsv[args.size()];
         int j = 0;

--- a/src/simon.h
+++ b/src/simon.h
@@ -31,6 +31,7 @@ struct global_t {
     std::iostream *output;
     bool is_test;
     long line;
+    str filename;
 };
 extern global_t global;
 

--- a/test.smn
+++ b/test.smn
@@ -35,6 +35,8 @@ end uses;
 
 include string;
 
+.include test2.smn;
+
 declare void, test();
 
 # Main Function
@@ -94,6 +96,8 @@ main;
     postwhile;
         println "One time println!";
     end postwhile, false;
+
+    test2;
 
     # Return a value of 0
     return 0;

--- a/test2.smn
+++ b/test2.smn
@@ -1,0 +1,5 @@
+/language: cpp/
+
+func void, test2;
+    println "test 2!";
+end func;


### PR DESCRIPTION
This adds a `.include` keyword, which allows you to include other simon files while compiling. SMN also now keeps track of which file its currently reading, for error messages.